### PR TITLE
return first match of dpkg-query status

### DIFF
--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -180,10 +180,10 @@ function hasPackage() {
 
     local ver
     local status
-    local out=$(dpkg-query -W --showformat='${Status} ${Version}' $1 2>/dev/null)
+    local out=$(dpkg-query -W --showformat='${Status};${Version};' $1 2>/dev/null)
     if [[ "$?" -eq 0 ]]; then
-        ver="${out##* }"
-        status="${out% *}"
+        ver="$(echo ${out} | awk -F';' '{ print $2 }')"
+        status="$(echo ${out} | awk -F';' '{ print $1 }')"
     fi
 
     local installed=0


### PR DESCRIPTION
fixes multiarch which would previously fail due to incorrect parsing of installed packages. the output of out would look like `install ok installed 2.26.1+dfsg-1install ok not-installed` and this would get parsed as having no version and status of not installed.